### PR TITLE
Support external link pragmas ::

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -413,7 +413,7 @@ impl Analyzer<'_> {
         match *pragma {
           Pragma::Canceled(k, n) => self.elab_canceled(it.pos, k, n),
           Pragma::SetVerify(b) => self.no_suppress_checker = b,
-          Pragma::ThmDesc(_) | Pragma::Insert(_) => {}
+          Pragma::ThmDesc(_) | Pragma::Insert(_) | Pragma::ExternalLink(_) => {}
           // This is intentionally stricter than necessary to ensure that MML has no weird
           // pragmas. The line below should be uncommented to allow pragmas for general use.
           // Pragma::Other(_) => {}
@@ -5081,7 +5081,7 @@ impl ReadProof for BlockReader {
         self.elab_canceled_def(elab, it.pos, n),
       (
         BlockKind::Registration | BlockKind::Definition,
-        ast::ItemKind::Pragma(Pragma::ThmDesc(_)),
+        ast::ItemKind::Pragma(Pragma::ThmDesc(_) | Pragma::ExternalLink(_)),
       ) => {}
       _ => return self.super_elab_item(elab, it, block_end),
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -927,6 +927,8 @@ pub enum Pragma {
   Insert(String),
   /// $V-, $V+
   SetVerify(bool),
+  /// $L
+  ExternalLink(String),
   Other(String),
 }
 
@@ -950,6 +952,8 @@ impl FromStr for Pragma {
       Pragma::ThmDesc(s.trim_start().to_owned())
     } else if let Some(s) = spelling.strip_prefix("$INSERT") {
       Pragma::Insert(s.trim_start().to_owned())
+    } else if let Some(s) = spelling.strip_prefix("$L") {
+      Pragma::ExternalLink(s.trim_start().to_owned())
     } else {
       match spelling {
         "$V-" => Pragma::SetVerify(false),


### PR DESCRIPTION
Mizar has extended the pragmas to include external links (they generically look like `::$L url text of link`). This patches mizar-rs to support these pragmas, otherwise mizar-rs will just throw errors since 90 articles use the pragma.