### PR TITLE
Schemes now do not require leading 'proof' keyword

### DIFF
--- a/src/parser/miz.rs
+++ b/src/parser/miz.rs
@@ -1265,7 +1265,9 @@ impl<'a> MizParser<'a> {
     } else {
       vec![]
     };
-    self.scan.accept(Keyword::Proof);
+    // leading "proof" keyword is now optional
+    if self.scan.try_accept(Keyword::Proof) {}
+    else { self.scan.accept(Keyword::Semicolon); }
     let (items, end) = self.parse_proof(false);
     self.scan.accept(Keyword::Semicolon);
     Box::new(SchemeBlock { end, head: SchemeHead { sym, nr: None, groups, concl, prems }, items })


### PR DESCRIPTION
Mizar changed its syntax for `scheme` blocks to now make the leading `proof` optional, according to the syntax.txt file:

```
Scheme-Block = "scheme" Scheme-Identifier "{" Scheme-Parameters "}" ":" Scheme-Conclusion [ "provided" Scheme-Premise { "and" Scheme-Premise } ] ( "proof" | ";" ) Reasoning "end" .
```

This syntax change will break Mizar-RS when it tries to check `field_16` (line 1490) and `pre_circ` (line 144).

But this pull request fixes Mizar-RS to handle these grammar changes.